### PR TITLE
Update pagination logic in list pages

### DIFF
--- a/src/Resources/CountryResource/Pages/ListCountries.php
+++ b/src/Resources/CountryResource/Pages/ListCountries.php
@@ -6,6 +6,8 @@ use Filament\Resources\Pages\ManageRecords;
 use TomatoPHP\FilamentLocations\Resources\CountryResource;
 use Filament\Actions;
 use Filament\Resources\Pages\ListRecords;
+use Illuminate\Contracts\Pagination\Paginator;
+use Illuminate\Database\Eloquent\Builder;
 
 class ListCountries extends ManageRecords
 {
@@ -22,5 +24,10 @@ class ListCountries extends ManageRecords
             Actions\CreateAction::make()
                 ->label(trans('filament-locations::messages.country.create')),
         ];
+    }
+
+    protected function paginateTableQuery(Builder $query): Paginator
+    {
+        return $query->simplePaginate(($this->getTableRecordsPerPage() === 'all') ? $query->count() : $this->getTableRecordsPerPage());
     }
 }

--- a/src/Resources/CurrencyResource/Pages/ListCurrencies.php
+++ b/src/Resources/CurrencyResource/Pages/ListCurrencies.php
@@ -7,6 +7,8 @@ use Illuminate\Database\Eloquent\Model;
 use TomatoPHP\FilamentLocations\Resources\CurrencyResource;
 use Filament\Actions;
 use Filament\Resources\Pages\ListRecords;
+use Illuminate\Contracts\Pagination\Paginator;
+use Illuminate\Database\Eloquent\Builder;
 
 class ListCurrencies extends ManageRecords
 {
@@ -23,5 +25,10 @@ class ListCurrencies extends ManageRecords
         return [
             Actions\CreateAction::make()->label(trans('filament-locations::messages.currency.create')),
         ];
+    }
+
+    protected function paginateTableQuery(Builder $query): Paginator
+    {
+        return $query->simplePaginate(($this->getTableRecordsPerPage() === 'all') ? $query->count() : $this->getTableRecordsPerPage());
     }
 }

--- a/src/Resources/LanguageResource/Pages/ListLanguages.php
+++ b/src/Resources/LanguageResource/Pages/ListLanguages.php
@@ -7,6 +7,8 @@ use Illuminate\Database\Eloquent\Model;
 use TomatoPHP\FilamentLocations\Resources\LanguageResource;
 use Filament\Actions;
 use Filament\Resources\Pages\ListRecords;
+use Illuminate\Contracts\Pagination\Paginator;
+use Illuminate\Database\Eloquent\Builder;
 
 class ListLanguages extends ManageRecords
 {
@@ -24,5 +26,10 @@ class ListLanguages extends ManageRecords
         return [
             Actions\CreateAction::make()->label(trans('filament-locations::messages.languages.create'))
         ];
+    }
+
+    protected function paginateTableQuery(Builder $query): Paginator
+    {
+        return $query->simplePaginate(($this->getTableRecordsPerPage() === 'all') ? $query->count() : $this->getTableRecordsPerPage());
     }
 }

--- a/src/Resources/LocationResource/Pages/ListLocations.php
+++ b/src/Resources/LocationResource/Pages/ListLocations.php
@@ -6,6 +6,8 @@ use Filament\Resources\Pages\ManageRecords;
 use TomatoPHP\FilamentLocations\Resources\LocationResource;
 use Filament\Actions;
 use Filament\Resources\Pages\ListRecords;
+use Illuminate\Contracts\Pagination\Paginator;
+use Illuminate\Database\Eloquent\Builder;
 
 class ListLocations extends ManageRecords
 {
@@ -22,5 +24,10 @@ class ListLocations extends ManageRecords
         return [
             Actions\CreateAction::make()->label(trans('filament-locations::messages.location.create')),
         ];
+    }
+
+    protected function paginateTableQuery(Builder $query): Paginator
+    {
+        return $query->simplePaginate(($this->getTableRecordsPerPage() === 'all') ? $query->count() : $this->getTableRecordsPerPage());
     }
 }


### PR DESCRIPTION
This pull request updates the pagination logic in the list pages for countries, currencies, languages, and locations. The `paginateTableQuery` method in each page now returns a `Paginator` instance instead of a `LengthAwarePaginator` instance. This change ensures that the pagination works correctly when the number of records per page is set to 'all'.

Also keeps the page load faster because not all data are loaded before opening the page. Instead the page loads a specific amount of data so when a user click on next button, the next N data will be loaded from the database.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced pagination capabilities for the Lists of Countries, Currencies, Languages, and Locations, allowing users to specify the number of records displayed per page or view all records at once.

These improvements provide a more flexible and user-friendly experience when managing and viewing records in the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->